### PR TITLE
KAAP-279: build & push pf9-kamaji controller image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,17 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= $(or $(shell git describe --abbrev=0 --tags 2>/dev/null),$(GIT_HEAD_COMMIT))
+# VERSION ?= $(or $(shell git describe --abbrev=0 --tags 2>/dev/null),$(GIT_HEAD_COMMIT))
+
+ifndef OVERRIDE_KAMAJI_VERSION
+	VERSION = $(shell ./get-label.bash)
+else
+	ifneq ($(strip $(OVERRIDE_KAMAJI_VERSION)),)
+		VERSION ?= $(OVERRIDE_KAMAJI_VERSION)
+	else
+		VERSION = $(shell ./get-label.bash)
+	endif
+endif
 
 # ENVTEST_K8S_VERSION specifies the Kubernetes version to be used 
 # during testing with the envtest environment. This ensures that 
@@ -20,7 +30,7 @@ ENVTEST_K8S_VERSION = 1.31.0
 ENVTEST_VERSION ?= release-0.19
 
 # Image URL to use all building/pushing image targets
-CONTAINER_REPOSITORY ?= docker.io/clastix/kamaji
+CONTAINER_REPOSITORY ?= quay.io/platform9/kamaji
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -107,5 +107,5 @@ kamaji-etcd:
 
 # -- Disable the analytics traces collection
 telemetry:
-  disabled: false
+  disabled: true
   

--- a/charts/kamaji/values.yaml
+++ b/charts/kamaji/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   # -- The container image of the Kamaji controller.
-  repository: clastix/kamaji
+  repository: quay.io/platform9/kamaji
   pullPolicy: Always
   # -- Overrides the image tag whose default is the chart appVersion.
   tag:

--- a/get-label.bash
+++ b/get-label.bash
@@ -1,0 +1,18 @@
+#!/bin/bash
+#First set the suffix to some value, either Teamcity build-id or <abbrev-sha1>
+if [[ -z "${TEAMCITY_BUILD_ID}" ]]; then
+    SUFFIX=$(git rev-parse --short HEAD)
+else
+    SUFFIX=${TEAMCITY_BUILD_ID}
+fi
+
+# Get the tag as the version
+TAG=$(git describe --tags HEAD)
+if [[ $? -ne 0 ]]
+then
+    # if we cannot get the tag, lets use the <branch>-pmk-<suffix> as the tag name
+    TAG=$(git rev-parse --abbrev-ref HEAD | sed 's/[^a-zA-Z0-9_.]/-/g')-kaapi-${SUFFIX}
+else
+    TAG=$(echo $TAG | sed 's/-.*//')-kaapi-${SUFFIX}
+fi
+echo $TAG


### PR DESCRIPTION
https://platform9.atlassian.net/browse/KAAP-279

So far we have been using upstream kamaji controller image.
This update will build from kamaji fork maintained by pf9 & use the same in kamaji controller deployment