### PR TITLE
fix(KAAP-1601): Update kamaji-etcd to 0.14.0 to support cert-manager

### DIFF
--- a/charts/kamaji/Chart.lock
+++ b/charts/kamaji/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kamaji-etcd
   repository: https://clastix.github.io/charts
-  version: 0.11.0
-digest: sha256:96b4115b8c02f771f809ec1bed3be3a3903e7e8315d6966aa54b0f73230ea421
-generated: "2025-07-03T09:19:19.835421461+02:00"
+  version: 0.14.0
+digest: sha256:ea1a46c19d1952de61bf804d22322b6898a03de80e0cad7f53da6d34e38a615a
+generated: "2026-02-06T22:24:55.15655+05:30"

--- a/charts/kamaji/Chart.yaml
+++ b/charts/kamaji/Chart.yaml
@@ -5,24 +5,24 @@ home: https://github.com/clastix/kamaji
 icon: https://github.com/clastix/kamaji/raw/master/assets/logo-colored.png
 kubeVersion: ">=1.21.0-0"
 maintainers:
-- email: dario@tranchitella.eu
-  name: Dario Tranchitella
-  url: https://clastix.io
-- email: me@maxgio.it
-  name: Massimiliano Giovagnoli
-- email: me@bsctl.io
-  name: Adriano Pezzuto
-  url: https://clastix.io
+  - email: dario@tranchitella.eu
+    name: Dario Tranchitella
+    url: https://clastix.io
+  - email: me@maxgio.it
+    name: Massimiliano Giovagnoli
+  - email: me@bsctl.io
+    name: Adriano Pezzuto
+    url: https://clastix.io
 name: kamaji
 sources:
-- https://github.com/clastix/kamaji
+  - https://github.com/clastix/kamaji
 type: application
 version: 0.0.0+latest
 dependencies:
-- name: kamaji-etcd
-  repository: https://clastix.github.io/charts
-  version: ">=0.11.0"
-  condition: kamaji-etcd.deploy
+  - name: kamaji-etcd
+    repository: https://clastix.github.io/charts
+    version: "0.14.0"
+    condition: kamaji-etcd.deploy
 annotations:
   catalog.cattle.io/certified: partner
   catalog.cattle.io/release-name: kamaji

--- a/charts/kamaji/README.md
+++ b/charts/kamaji/README.md
@@ -22,7 +22,7 @@ Kubernetes: `>=1.21.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://clastix.github.io/charts | kamaji-etcd | >=0.11.0 |
+| https://clastix.github.io/charts | kamaji-etcd | 0.14.0 |
 
 [Kamaji](https://github.com/clastix/kamaji) requires a [multi-tenant `etcd`](https://github.com/clastix/kamaji-internal/blob/master/deploy/getting-started-with-kamaji.md#setup-internal-multi-tenant-etcd) cluster.
 This Helm Chart starting from v0.1.1 provides the installation of an internal `etcd` in order to streamline the local test. If you'd like to use an externally managed etcd instance, you can specify the overrides and by setting the value `etcd.deploy=false`.


### PR DESCRIPTION
We want cert-manager to rotate the client, peer and server certs of the kamaji-etcd. Support for the same is added in the kamaji-etcd version above 0.14.0